### PR TITLE
Upgrade failure: use `.timestamp()` as `cur_time` instead of `datetime`

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,4 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2 
       - run: python tests.py
-      
+    steps:
+      - uses: actions/checkout@v2
+      - name: Unit tests
+        run: python tests.py
+      - name: Concurrency tests
+        run: python test_cmus_status_scrobbler.py

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,9 +8,6 @@ jobs:
   Run-Tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2 
-      - run: python tests.py
-    steps:
       - uses: actions/checkout@v2
       - name: Unit tests
         run: python tests.py

--- a/cmus_status_scrobbler.py
+++ b/cmus_status_scrobbler.py
@@ -62,6 +62,9 @@ class StatusDB:
         status_updates = []
         for row in cur:
             status_updates.append(pickle.loads(row[0]))
+            su = status_updates[-1]
+            if isinstance(su.cur_time, datetime.datetime):
+                status_updates[-1] = su._replace(cur_time=su.cur_time.timestamp())
         return status_updates
 
     def clear(self):
@@ -175,10 +178,7 @@ class Scrobbler:
             f'track[{i}]':
             su.title,
             f'timestamp[{i}]':
-            str(
-                int(
-                    su.cur_time.replace(
-                        tzinfo=datetime.timezone.utc).timestamp())),
+            str(int(su.cur_time)),
             f'album[{i}]':
             su.album,
             f'trackNumber[{i}]':
@@ -238,7 +238,7 @@ class Scrobbler:
 
 def parse_cmus_status_line(ls):
     r = dict(
-        cur_time=datetime.datetime.now(datetime.timezone.utc),
+        cur_time=datetime.datetime.now(datetime.timezone.utc).timestamp(),
         musicbrainz_trackid=None,
         discnumber=1,
         tracknumber=None,
@@ -320,7 +320,7 @@ def calculate_scrobbles(status_updates, perc_thresh=0.5, secs_thresh=4 * 60):
 
         if equal_tracks(cur, nxt2) and nxt2.status == CmusStatus.playing:
             # playing continued, keeping already played time for next
-            ptbp += (nxt.cur_time - cur.cur_time).total_seconds()
+            ptbp += nxt.cur_time - cur.cur_time
             ptbp_status = cur if not ptbp_status else ptbp_status
             continue
         # playing did not continue, nxt2 file is not None and it's either a

--- a/cmus_status_scrobbler.py
+++ b/cmus_status_scrobbler.py
@@ -258,7 +258,7 @@ def has_played_enough(start_ts,
                       secs_thresh,
                       ptbp=0):
     duration = int(duration)
-    total = (end_ts - start_ts).total_seconds() + ptbp
+    total = end_ts - start_ts + ptbp
     return total / duration >= perc_thresh or total >= secs_thresh
 
 

--- a/cmus_status_scrobbler.py
+++ b/cmus_status_scrobbler.py
@@ -64,6 +64,7 @@ class StatusDB:
             status_updates.append(pickle.loads(row[0]))
             su = status_updates[-1]
             if isinstance(su.cur_time, datetime.datetime):
+                # FIXME remove in 3 years, assuming everyone is on latest
                 status_updates[-1] = su._replace(cur_time=su.cur_time.timestamp())
         return status_updates
 

--- a/test_cmus_status_scrobbler.py
+++ b/test_cmus_status_scrobbler.py
@@ -9,6 +9,15 @@ CMUS_STATUS_SCROBBLER_PATH = './cmus_status_scrobbler.py'
 INI_PATH = './test.ini'
 DB_PATH = './test.sqlite3'
 
+def run_scrobbler():
+    subprocess.run([
+        PYTHON_EXECUTABLE, CMUS_STATUS_SCROBBLER_PATH, '--ini', INI_PATH,
+        'status', 'playing', 'file', '/home/user/Music/song1.mp3',
+        'artist', 'Artist A', 'album', 'Album X', 'title', 'Song 1',
+        'duration', '240'
+    ])
+
+
 class TestCmusStatusScrobblerIntegration(unittest.TestCase):
 
     def setUp(self):
@@ -29,14 +38,6 @@ class TestCmusStatusScrobblerIntegration(unittest.TestCase):
 
     def test_multiple_invocations_with_empty_status(self):
         # Define a function to run cmus_status_scrobbler.py
-        def run_scrobbler():
-            subprocess.run([
-                PYTHON_EXECUTABLE, CMUS_STATUS_SCROBBLER_PATH, '--ini', INI_PATH,
-                'status', 'playing', 'file', '/home/user/Music/song1.mp3',
-                'artist', 'Artist A', 'album', 'Album X', 'title', 'Song 1',
-                'duration', '240'
-            ])
-
         # Create and start multiple processes
         processes = [Process(target=run_scrobbler) for _ in range(5)]
         for p in processes:

--- a/tests.py
+++ b/tests.py
@@ -11,7 +11,10 @@ def secs(n):
     return datetime.timedelta(seconds=n)
 
 
-SS = namedtuple('SS', 'cur_time duration file status')
+_SS = namedtuple('_SS', 'cur_time duration file status')
+
+def SS(*, cur_time, duration, file, status):
+   return _SS(cur_time=cur_time.timestamp(), duration=duration, file=file, status=status)
 
 
 class TestCalculateScrobbles(unittest.TestCase):
@@ -21,7 +24,7 @@ class TestCalculateScrobbles(unittest.TestCase):
             self.assertEqual(expected, actual)
 
     def test_simple_play_stop(self):
-        d = datetime.datetime.utcnow()
+        d = datetime.datetime.now(datetime.timezone.utc)
         ss = [
             SS(cur_time=d, duration=5, file='A', status=CmusStatus.playing),
             SS(cur_time=d + secs(4),
@@ -35,7 +38,7 @@ class TestCalculateScrobbles(unittest.TestCase):
         self.assertEqual(ss[0], scrobbles[0])
 
     def test_repeat(self):
-        d = datetime.datetime.utcnow()
+        d = datetime.datetime.now(datetime.timezone.utc)
         ss = [
             SS(cur_time=d, duration=5, file='A', status=CmusStatus.playing),
             SS(cur_time=d + secs(4),
@@ -50,7 +53,7 @@ class TestCalculateScrobbles(unittest.TestCase):
         self.assertEqual(ss[1], leftovers[0])
 
     def test_play_pause(self):
-        d = datetime.datetime.utcnow()
+        d = datetime.datetime.now(datetime.timezone.utc)
         ss = [
             SS(cur_time=d, duration=5, file='A', status=CmusStatus.playing),
             SS(cur_time=d + secs(4),
@@ -65,7 +68,7 @@ class TestCalculateScrobbles(unittest.TestCase):
         self.assertEqual(ss[1], leftovers[1])
 
     def test_play_pause_stopped(self):
-        d = datetime.datetime.utcnow()
+        d = datetime.datetime.now(datetime.timezone.utc)
         ss = [
             SS(cur_time=d, duration=5, file='A', status=CmusStatus.playing),
             SS(
@@ -83,7 +86,7 @@ class TestCalculateScrobbles(unittest.TestCase):
         self.assertEqual([], leftovers)
 
     def test_play_pause_play_pause_dotdotdot_stopped(self):
-        d = datetime.datetime.utcnow()
+        d = datetime.datetime.now(datetime.timezone.utc)
         ss = [
             SS(cur_time=d, duration=10, file='A', status=CmusStatus.playing),
             SS(cur_time=d + secs(1),
@@ -141,7 +144,7 @@ class TestCalculateScrobbles(unittest.TestCase):
         self.assertEqual(ss[0], scrobbles[0])
 
     def test_play_pause_stopped_enough_time_played(self):
-        d = datetime.datetime.utcnow()
+        d = datetime.datetime.now(datetime.timezone.utc)
         ss = [
             SS(cur_time=d, duration=5, file='A', status=CmusStatus.playing),
             SS(
@@ -159,7 +162,7 @@ class TestCalculateScrobbles(unittest.TestCase):
         self.assertEqual(ss[0], scrobbles[0])
 
     def test_normal_player_status(self):
-        d = datetime.datetime.utcnow()
+        d = datetime.datetime.now(datetime.timezone.utc)
         ss = [
             SS(cur_time=d, duration=1, file='A', status=CmusStatus.playing),
             SS(cur_time=d + secs(2),
@@ -193,7 +196,7 @@ class TestCalculateScrobbles(unittest.TestCase):
         self.assertArrayEqual(ss[:-1], scrobbles)
 
     def test_pause_play_suffix_leftovers(self):
-        d = datetime.datetime.utcnow()
+        d = datetime.datetime.now(datetime.timezone.utc)
         ss = [
             SS(cur_time=d, duration=1, file='A', status=CmusStatus.playing),
             SS(cur_time=d + secs(2),
@@ -257,7 +260,7 @@ class TestCalculateScrobbles(unittest.TestCase):
         #   1. stopped
         #   2. playing again
         #   3. different file
-        d = datetime.datetime.utcnow()
+        d = datetime.datetime.now(datetime.timezone.utc)
         a = dict(cur_time=d, duration=10, file='A', status=CmusStatus.playing)
         for stop in [
                 dict(file='B'),

--- a/tests.py
+++ b/tests.py
@@ -16,6 +16,8 @@ _SS = namedtuple('_SS', 'cur_time duration file status')
 def SS(*, cur_time, duration, file, status):
    return _SS(cur_time=cur_time.timestamp(), duration=duration, file=file, status=status)
 
+def utcnow():
+   return datetime.datetime.now(datetime.timezone.utc)
 
 class TestCalculateScrobbles(unittest.TestCase):
 
@@ -24,7 +26,7 @@ class TestCalculateScrobbles(unittest.TestCase):
             self.assertEqual(expected, actual)
 
     def test_simple_play_stop(self):
-        d = datetime.datetime.now(datetime.timezone.utc)
+        d = utcnow()
         ss = [
             SS(cur_time=d, duration=5, file='A', status=CmusStatus.playing),
             SS(cur_time=d + secs(4),
@@ -38,7 +40,7 @@ class TestCalculateScrobbles(unittest.TestCase):
         self.assertEqual(ss[0], scrobbles[0])
 
     def test_repeat(self):
-        d = datetime.datetime.now(datetime.timezone.utc)
+        d = utcnow()
         ss = [
             SS(cur_time=d, duration=5, file='A', status=CmusStatus.playing),
             SS(cur_time=d + secs(4),
@@ -53,7 +55,7 @@ class TestCalculateScrobbles(unittest.TestCase):
         self.assertEqual(ss[1], leftovers[0])
 
     def test_play_pause(self):
-        d = datetime.datetime.now(datetime.timezone.utc)
+        d = utcnow()
         ss = [
             SS(cur_time=d, duration=5, file='A', status=CmusStatus.playing),
             SS(cur_time=d + secs(4),
@@ -68,7 +70,7 @@ class TestCalculateScrobbles(unittest.TestCase):
         self.assertEqual(ss[1], leftovers[1])
 
     def test_play_pause_stopped(self):
-        d = datetime.datetime.now(datetime.timezone.utc)
+        d = utcnow()
         ss = [
             SS(cur_time=d, duration=5, file='A', status=CmusStatus.playing),
             SS(
@@ -86,7 +88,7 @@ class TestCalculateScrobbles(unittest.TestCase):
         self.assertEqual([], leftovers)
 
     def test_play_pause_play_pause_dotdotdot_stopped(self):
-        d = datetime.datetime.now(datetime.timezone.utc)
+        d = utcnow()
         ss = [
             SS(cur_time=d, duration=10, file='A', status=CmusStatus.playing),
             SS(cur_time=d + secs(1),
@@ -144,7 +146,7 @@ class TestCalculateScrobbles(unittest.TestCase):
         self.assertEqual(ss[0], scrobbles[0])
 
     def test_play_pause_stopped_enough_time_played(self):
-        d = datetime.datetime.now(datetime.timezone.utc)
+        d = utcnow()
         ss = [
             SS(cur_time=d, duration=5, file='A', status=CmusStatus.playing),
             SS(
@@ -162,7 +164,7 @@ class TestCalculateScrobbles(unittest.TestCase):
         self.assertEqual(ss[0], scrobbles[0])
 
     def test_normal_player_status(self):
-        d = datetime.datetime.now(datetime.timezone.utc)
+        d = utcnow()
         ss = [
             SS(cur_time=d, duration=1, file='A', status=CmusStatus.playing),
             SS(cur_time=d + secs(2),
@@ -196,7 +198,7 @@ class TestCalculateScrobbles(unittest.TestCase):
         self.assertArrayEqual(ss[:-1], scrobbles)
 
     def test_pause_play_suffix_leftovers(self):
-        d = datetime.datetime.now(datetime.timezone.utc)
+        d = utcnow()
         ss = [
             SS(cur_time=d, duration=1, file='A', status=CmusStatus.playing),
             SS(cur_time=d + secs(2),
@@ -260,7 +262,7 @@ class TestCalculateScrobbles(unittest.TestCase):
         #   1. stopped
         #   2. playing again
         #   3. different file
-        d = datetime.datetime.now(datetime.timezone.utc)
+        d = utcnow()
         a = dict(cur_time=d, duration=10, file='A', status=CmusStatus.playing)
         for stop in [
                 dict(file='B'),


### PR DESCRIPTION
If db has some entries without tz, upgrading to new version breaks everything.

Having long lived `datetime` objects is a plague that I thought I wouldn't encounter in my code.
Switch to timestamps.
Should have known better.